### PR TITLE
Fix typo in dry run message

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -139,7 +139,7 @@ describe("main", () => {
 
       await expect(main()).rejects.toThrow("process.exit: 0");
       expect(prompt).toHaveBeenCalledWith(
-        expect.stringContaining("(this is a dry, run nothing will be deleted)"),
+        expect.stringContaining("(this is a dry run, nothing will be deleted)"),
       );
       expect(deleteFolders).not.toHaveBeenCalled();
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,9 +85,9 @@ const buildConfirmationMessage = (isDryRun: boolean) => {
   const confirmationPrompt = chalk.italic("(yes/no) ");
 
   if (isDryRun) {
-    const dryRunNotice = chalk.bold(
-      chalk.blue("(this is a dry, run nothing will be deleted)"),
-    );
+      const dryRunNotice = chalk.bold(
+        chalk.blue("(this is a dry run, nothing will be deleted)"),
+      );
     return `${baseMessage} ${dryRunNotice} ${confirmationPrompt}`;
   }
 


### PR DESCRIPTION
## Summary
- fix dry run message wording
- update test expectations

## Testing
- `bun run test --run`

------
https://chatgpt.com/codex/tasks/task_e_684a224d3cf48324a6627def65bba572